### PR TITLE
fix(security): sanitize API pagination parameters

### DIFF
--- a/src/app/api/transactions/history/route.ts
+++ b/src/app/api/transactions/history/route.ts
@@ -20,7 +20,9 @@ export async function GET(req: NextRequest) {
 
     const supabase = createServerClient()
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
+
+    const rawLimit = parseInt(searchParams.get('limit') || '50')
+    const limit = isNaN(rawLimit) || rawLimit < 1 ? 50 : Math.min(rawLimit, 100)
 
     // 1. Fetch Sent Transactions (where customer_wallet = walletAddress)
     const { data: sentTransactions, error: sentError } = await supabase

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -19,7 +19,9 @@ export async function GET(req: NextRequest) {
     const supabase = createServerClient()
     const { searchParams } = new URL(req.url)
     const paymentLinkId = searchParams.get('payment_link_id')
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
+
+    const rawLimit = parseInt(searchParams.get('limit') || '50')
+    const limit = isNaN(rawLimit) || rawLimit < 1 ? 50 : Math.min(rawLimit, 100)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let query = (supabase.from('transactions') as any)

--- a/src/app/api/v1/payment-links/route.ts
+++ b/src/app/api/v1/payment-links/route.ts
@@ -183,8 +183,13 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+
+    // Parse pagination parameters securely to avoid NaN or negative values
+    const rawLimit = parseInt(searchParams.get('limit') || '10')
+    const limit = isNaN(rawLimit) || rawLimit < 1 ? 10 : Math.min(rawLimit, 100)
+
+    const rawOffset = parseInt(searchParams.get('offset') || '0')
+    const offset = isNaN(rawOffset) || rawOffset < 0 ? 0 : rawOffset
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const supabase = createServerClient() as any

--- a/src/app/api/v1/transactions/route.ts
+++ b/src/app/api/v1/transactions/route.ts
@@ -10,8 +10,13 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+
+    const rawLimit = parseInt(searchParams.get('limit') || '10')
+    const limit = isNaN(rawLimit) || rawLimit < 1 ? 10 : Math.min(rawLimit, 100)
+
+    const rawOffset = parseInt(searchParams.get('offset') || '0')
+    const offset = isNaN(rawOffset) || rawOffset < 0 ? 0 : rawOffset
+
     const status = searchParams.get('status')
     const paymentLinkId = searchParams.get('payment_link_id')
     


### PR DESCRIPTION
Category: Security
Priority: P0
What: Fixed pagination security in API routes (`src/app/api/v1/payment-links/route.ts`, `src/app/api/v1/transactions/route.ts`, `src/app/api/transactions/route.ts`, `src/app/api/transactions/history/route.ts`) by properly sanitizing `limit` and `offset` query parameters.
Why: Previous implementation used `parseInt` without checking for `NaN`. Providing non-numeric or negative values could result in `NaN` or negative boundaries being passed directly to Supabase `.range()` and `.limit()`, causing runtime errors or unexpected behavior.
Impact: Prevents potential DoS or runtime database exceptions from maliciously crafted query parameters.
Verification: Ran `npm run lint` and `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=dummy npm run build` successfully. Verified that default safe boundaries are applied when `NaN` or negative values are provided.

---
*PR created automatically by Jules for task [6495204142204813755](https://jules.google.com/task/6495204142204813755) started by @Shreyassp002*