### PR TITLE
fix(security): prevent NaN and negative pagination values in API routes

### DIFF
--- a/src/app/api/transactions/history/route.ts
+++ b/src/app/api/transactions/history/route.ts
@@ -20,7 +20,8 @@ export async function GET(req: NextRequest) {
 
     const supabase = createServerClient()
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
+    const rawLimit = parseInt(searchParams.get('limit') || '50')
+    const limit = isNaN(rawLimit) || rawLimit < 1 ? 50 : Math.min(rawLimit, 100)
 
     // 1. Fetch Sent Transactions (where customer_wallet = walletAddress)
     const { data: sentTransactions, error: sentError } = await supabase

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -19,7 +19,8 @@ export async function GET(req: NextRequest) {
     const supabase = createServerClient()
     const { searchParams } = new URL(req.url)
     const paymentLinkId = searchParams.get('payment_link_id')
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
+    const rawLimit = parseInt(searchParams.get('limit') || '50')
+    const limit = isNaN(rawLimit) || rawLimit < 1 ? 50 : Math.min(rawLimit, 100)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let query = (supabase.from('transactions') as any)

--- a/src/app/api/v1/payment-links/route.ts
+++ b/src/app/api/v1/payment-links/route.ts
@@ -183,8 +183,10 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+    const rawLimit = parseInt(searchParams.get('limit') || '10')
+    const limit = isNaN(rawLimit) || rawLimit < 1 ? 10 : Math.min(rawLimit, 100)
+    const rawOffset = parseInt(searchParams.get('offset') || '0')
+    const offset = isNaN(rawOffset) || rawOffset < 0 ? 0 : rawOffset
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const supabase = createServerClient() as any

--- a/src/app/api/v1/transactions/route.ts
+++ b/src/app/api/v1/transactions/route.ts
@@ -10,8 +10,10 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+    const rawLimit = parseInt(searchParams.get('limit') || '10')
+    const limit = isNaN(rawLimit) || rawLimit < 1 ? 10 : Math.min(rawLimit, 100)
+    const rawOffset = parseInt(searchParams.get('offset') || '0')
+    const offset = isNaN(rawOffset) || rawOffset < 0 ? 0 : rawOffset
     const status = searchParams.get('status')
     const paymentLinkId = searchParams.get('payment_link_id')
     


### PR DESCRIPTION
Category: Security
Priority: P1
What: Fixed API pagination to validate limit and offset bounds and fallback if they are NaN.
Why: If a user sends a string like ?limit=abc, parseInt returns NaN, which propagates to Supabase .range(), leading to 500 Internal Server Errors or unbounded queries that could act as a DoS vector.
Impact: Safely validates and constrains user input before it hits the database.
Verification: Ran npm run lint and NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=dummy npm run build.

---
*PR created automatically by Jules for task [6377543979634899](https://jules.google.com/task/6377543979634899) started by @Shreyassp002*