### PR TITLE
fix: validate and bound pagination limit and offset in API routes

### DIFF
--- a/src/app/api/transactions/history/route.ts
+++ b/src/app/api/transactions/history/route.ts
@@ -20,7 +20,10 @@ export async function GET(req: NextRequest) {
 
     const supabase = createServerClient()
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
+
+    let limit = parseInt(searchParams.get('limit') || '50')
+    if (isNaN(limit) || limit < 1) limit = 50
+    limit = Math.min(limit, 100)
 
     // 1. Fetch Sent Transactions (where customer_wallet = walletAddress)
     const { data: sentTransactions, error: sentError } = await supabase

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -19,7 +19,10 @@ export async function GET(req: NextRequest) {
     const supabase = createServerClient()
     const { searchParams } = new URL(req.url)
     const paymentLinkId = searchParams.get('payment_link_id')
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
+
+    let limit = parseInt(searchParams.get('limit') || '50')
+    if (isNaN(limit) || limit < 1) limit = 50
+    limit = Math.min(limit, 100)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let query = (supabase.from('transactions') as any)

--- a/src/app/api/v1/payment-links/route.ts
+++ b/src/app/api/v1/payment-links/route.ts
@@ -183,8 +183,13 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+
+    let limit = parseInt(searchParams.get('limit') || '10')
+    if (isNaN(limit) || limit < 1) limit = 10
+    limit = Math.min(limit, 100)
+
+    let offset = parseInt(searchParams.get('offset') || '0')
+    if (isNaN(offset) || offset < 0) offset = 0
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const supabase = createServerClient() as any

--- a/src/app/api/v1/transactions/route.ts
+++ b/src/app/api/v1/transactions/route.ts
@@ -10,8 +10,14 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+
+    let limit = parseInt(searchParams.get('limit') || '10')
+    if (isNaN(limit) || limit < 1) limit = 10
+    limit = Math.min(limit, 100)
+
+    let offset = parseInt(searchParams.get('offset') || '0')
+    if (isNaN(offset) || offset < 0) offset = 0
+
     const status = searchParams.get('status')
     const paymentLinkId = searchParams.get('payment_link_id')
     


### PR DESCRIPTION
Category: Bug
Priority: P1
What: Added `isNaN` and negative value checks to `limit` and `offset` parsing across four transaction and payment-link API routes. It ensures that variables use safe defaults and limits.
Why: If a client sends a non-numeric string (e.g. `?limit=abc`), `parseInt` returns `NaN`, and `Math.min(NaN, 100)` evaluates to `NaN`. Passing `NaN` into Supabase database queries causes errors or undefined behaviors.
Impact: Prevents database query failures due to malformed pagination parameters.
Verification: Ran `npm run lint` and `npm run build` which passed successfully. Verified that `package.json` changes were omitted as per project boundaries.

---
*PR created automatically by Jules for task [13643944272714269455](https://jules.google.com/task/13643944272714269455) started by @Shreyassp002*