### PR TITLE
fix(security): sanitize pagination parameters to prevent DB errors

### DIFF
--- a/src/app/api/transactions/history/route.ts
+++ b/src/app/api/transactions/history/route.ts
@@ -20,7 +20,9 @@ export async function GET(req: NextRequest) {
 
     const supabase = createServerClient()
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
+    let parsedLimit = parseInt(searchParams.get('limit') || '50', 10)
+    if (isNaN(parsedLimit) || parsedLimit < 1) parsedLimit = 50
+    const limit = Math.min(parsedLimit, 100)
 
     // 1. Fetch Sent Transactions (where customer_wallet = walletAddress)
     const { data: sentTransactions, error: sentError } = await supabase

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -19,7 +19,9 @@ export async function GET(req: NextRequest) {
     const supabase = createServerClient()
     const { searchParams } = new URL(req.url)
     const paymentLinkId = searchParams.get('payment_link_id')
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
+    let parsedLimit = parseInt(searchParams.get('limit') || '50', 10)
+    if (isNaN(parsedLimit) || parsedLimit < 1) parsedLimit = 50
+    const limit = Math.min(parsedLimit, 100)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let query = (supabase.from('transactions') as any)

--- a/src/app/api/v1/payment-links/route.ts
+++ b/src/app/api/v1/payment-links/route.ts
@@ -183,8 +183,12 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+    let parsedLimit = parseInt(searchParams.get('limit') || '10', 10)
+    if (isNaN(parsedLimit) || parsedLimit < 1) parsedLimit = 10
+    const limit = Math.min(parsedLimit, 100)
+
+    let offset = parseInt(searchParams.get('offset') || '0', 10)
+    if (isNaN(offset) || offset < 0) offset = 0
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const supabase = createServerClient() as any

--- a/src/app/api/v1/transactions/route.ts
+++ b/src/app/api/v1/transactions/route.ts
@@ -10,8 +10,13 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+    let parsedLimit = parseInt(searchParams.get('limit') || '10', 10)
+    if (isNaN(parsedLimit) || parsedLimit < 1) parsedLimit = 10
+    const limit = Math.min(parsedLimit, 100)
+
+    let offset = parseInt(searchParams.get('offset') || '0', 10)
+    if (isNaN(offset) || offset < 0) offset = 0
+
     const status = searchParams.get('status')
     const paymentLinkId = searchParams.get('payment_link_id')
     


### PR DESCRIPTION
**Category:** Security
**Priority:** P1
**What:** Updated `limit` and `offset` parsing logic across 4 transaction and payment-link API routes. `parseInt` now explicitly uses base 10 and explicitly handles `NaN` and negative values by falling back to safe defaults before applying the `Math.min()` limit constraint.
**Why:** If an API client queries `?limit=not-a-number` or `?offset=-10`, `parseInt` would return `NaN` or a negative value respectively. This gets passed into Supabase `.range()` or `.limit()`, causing the database query to fail or throw unhandled promise rejections, resulting in 500 API errors and breaking functionality.
**Impact:** Paginated API endpoints are now robust against malformed input parameters, ensuring they return safe fallback defaults instead of database errors.
**Verification:**
- Ran `npm run lint` successfully.
- Ran `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=dummy npm run build` successfully.

---
*PR created automatically by Jules for task [7051721128769812940](https://jules.google.com/task/7051721128769812940) started by @Shreyassp002*