### PR TITLE
fix(security): apply valid range limits to api pagination input

### DIFF
--- a/src/app/api/v1/payment-links/route.ts
+++ b/src/app/api/v1/payment-links/route.ts
@@ -183,8 +183,10 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+    const parsedLimit = parseInt(searchParams.get('limit') || '10')
+    const limit = isNaN(parsedLimit) || parsedLimit <= 0 ? 10 : Math.min(parsedLimit, 100)
+    const parsedOffset = parseInt(searchParams.get('offset') || '0')
+    const offset = isNaN(parsedOffset) || parsedOffset < 0 ? 0 : parsedOffset
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const supabase = createServerClient() as any

--- a/src/app/api/v1/transactions/route.ts
+++ b/src/app/api/v1/transactions/route.ts
@@ -10,8 +10,10 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+    const parsedLimit = parseInt(searchParams.get('limit') || '10')
+    const limit = isNaN(parsedLimit) || parsedLimit <= 0 ? 10 : Math.min(parsedLimit, 100)
+    const parsedOffset = parseInt(searchParams.get('offset') || '0')
+    const offset = isNaN(parsedOffset) || parsedOffset < 0 ? 0 : parsedOffset
     const status = searchParams.get('status')
     const paymentLinkId = searchParams.get('payment_link_id')
     


### PR DESCRIPTION
Category: Security
Priority: P1
What: Safely parsed limit and offset query parameters in `/api/v1/payment-links` and `/api/v1/transactions` routes using `isNaN` checks and constraining to valid boundaries.
Why: The previous implementation allowed `NaN` and negative limits by incorrectly passing unvalidated strings into `parseInt`, causing invalid `limit` and `offset` values passed to Supabase's `.range()` query which could result in server errors or unconstrained data pulls.
Impact: Safe and predictable database queries, mitigating potential DoS or error spew. 
Verification: Ran `npm run lint` and `npm run build` locally successfully.

---
*PR created automatically by Jules for task [4395534982611346774](https://jules.google.com/task/4395534982611346774) started by @Shreyassp002*