### PR TITLE
fix(security): sanitize api pagination parameters

### DIFF
--- a/src/app/api/transactions/history/route.ts
+++ b/src/app/api/transactions/history/route.ts
@@ -20,7 +20,8 @@ export async function GET(req: NextRequest) {
 
     const supabase = createServerClient()
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
+    const parsedLimit = parseInt(searchParams.get('limit') || '50')
+    const limit = isNaN(parsedLimit) || parsedLimit < 1 ? 50 : Math.min(parsedLimit, 100)
 
     // 1. Fetch Sent Transactions (where customer_wallet = walletAddress)
     const { data: sentTransactions, error: sentError } = await supabase

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -19,7 +19,8 @@ export async function GET(req: NextRequest) {
     const supabase = createServerClient()
     const { searchParams } = new URL(req.url)
     const paymentLinkId = searchParams.get('payment_link_id')
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
+    const parsedLimit = parseInt(searchParams.get('limit') || '50')
+    const limit = isNaN(parsedLimit) || parsedLimit < 1 ? 50 : Math.min(parsedLimit, 100)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let query = (supabase.from('transactions') as any)

--- a/src/app/api/v1/payment-links/route.ts
+++ b/src/app/api/v1/payment-links/route.ts
@@ -183,8 +183,10 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+    const parsedLimit = parseInt(searchParams.get('limit') || '10')
+    const limit = isNaN(parsedLimit) || parsedLimit < 1 ? 10 : Math.min(parsedLimit, 100)
+    const parsedOffset = parseInt(searchParams.get('offset') || '0')
+    const offset = isNaN(parsedOffset) || parsedOffset < 0 ? 0 : parsedOffset
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const supabase = createServerClient() as any

--- a/src/app/api/v1/transactions/route.ts
+++ b/src/app/api/v1/transactions/route.ts
@@ -10,8 +10,10 @@ export async function GET(req: NextRequest) {
     }
 
     const { searchParams } = new URL(req.url)
-    const limit = Math.min(parseInt(searchParams.get('limit') || '10'), 100)
-    const offset = parseInt(searchParams.get('offset') || '0')
+    const parsedLimit = parseInt(searchParams.get('limit') || '10')
+    const limit = isNaN(parsedLimit) || parsedLimit < 1 ? 10 : Math.min(parsedLimit, 100)
+    const parsedOffset = parseInt(searchParams.get('offset') || '0')
+    const offset = isNaN(parsedOffset) || parsedOffset < 0 ? 0 : parsedOffset
     const status = searchParams.get('status')
     const paymentLinkId = searchParams.get('payment_link_id')
     


### PR DESCRIPTION
Category: Security
Priority: P1
What: Added explicit `isNaN` validation and lower bound checks for `limit` and `offset` query parameters across transaction and payment link API endpoints (`/api/v1/payment-links`, `/api/v1/transactions`, `/api/transactions`, `/api/transactions/history`).
Why: Passing unvalidated `NaN` or negative values to Supabase `.range()` or `.limit()` caused unhandled errors, crashing the route and creating DoS vulnerability vectors.
Impact: Improved API resilience by safely falling back to defaults (limit 10/50, offset 0) and preventing database crashes from malformed inputs.
Verification: Evaluated `npm run lint` and `npm run build` which passed successfully.

---
*PR created automatically by Jules for task [14301886515865622520](https://jules.google.com/task/14301886515865622520) started by @Shreyassp002*